### PR TITLE
Feature/set git details

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -227,6 +227,18 @@ runs:
         IMAGE_NAME: ${{ inputs.image }}
         IMAGE_TAG: ${{ inputs.image-tag }}
 
+    - name: Deplicated Ref
+      if: ${{ inputs.operation == 'deploy' }}
+      id: ref
+      uses: cloudposse/github-action-yaml-config-query@0.1.3
+      with:
+        query: .${{ inputs.gitref-sha == '' }}
+        config: |-
+          true: 
+            value: ${{ inputs.ref }}
+          false:
+            value: ${{ inputs.gitref-sha }}      
+
     - name: Helm raw render
       if: ${{ inputs.toolchain == 'helm' && inputs.operation == 'deploy' }}
       shell: bash
@@ -239,6 +251,8 @@ runs:
           --namespace ${{ inputs.namespace }} \
           ${{ env.HELM_DEBUG_FLAG }} \
           --set ingress.default.hosts.example=test \
+          --set github.ref=${{ steps.ref.outputs.value }} \
+          --set github.repository=${{ inputs.repository }} \
           --values $(pwd)/service.yaml \
           --values $(pwd)/platform.yaml \
           --values "${{ inputs.helm-values-file }}" \
@@ -258,18 +272,6 @@ runs:
             ${{ steps.config.outputs.tmp }}/manifests/resources.yaml \
         )
         echo "webapp_url=${WEBAPP_URL}" >> $GITHUB_OUTPUT
-
-    - name: Deplicated Ref
-      if: ${{ inputs.operation == 'deploy' }}
-      id: ref
-      uses: cloudposse/github-action-yaml-config-query@0.1.3
-      with:
-        query: .${{ inputs.gitref-sha == '' }}
-        config: |-
-          true: 
-            value: ${{ inputs.ref }}
-          false:
-            value: ${{ inputs.gitref-sha }}      
 
     - name: Config render
       if: ${{ inputs.operation == 'deploy' }}

--- a/action.yml
+++ b/action.yml
@@ -209,6 +209,18 @@ runs:
       shell: bash
       run: echo "HELM_DEBUG_FLAG=--debug" >> $GITHUB_ENV
 
+    - name: Deplicated Ref
+      if: ${{ inputs.operation == 'deploy' }}
+      id: ref
+      uses: cloudposse/github-action-yaml-config-query@0.1.3
+      with:
+        query: .${{ inputs.gitref-sha == '' }}
+        config: |-
+          true: 
+            value: ${{ inputs.ref }}
+          false:
+            value: ${{ inputs.gitref-sha }}
+          
     - name: Helmfile render
       if: ${{ inputs.toolchain == 'helmfile' && inputs.operation == 'deploy' }}
       shell: bash
@@ -222,22 +234,12 @@ runs:
           --state-values-file "${{ inputs.helm-values-file }}" \
           template \
           --args="${{ steps.arguments.outputs.kube_version }}" \
+          --set github.ref=${{ steps.ref.outputs.value }} \
+          --set github.repository=${{ inputs.repository }} \
           > ${{ steps.config.outputs.tmp }}/manifests/resources.yaml
       env:
         IMAGE_NAME: ${{ inputs.image }}
         IMAGE_TAG: ${{ inputs.image-tag }}
-
-    - name: Deplicated Ref
-      if: ${{ inputs.operation == 'deploy' }}
-      id: ref
-      uses: cloudposse/github-action-yaml-config-query@0.1.3
-      with:
-        query: .${{ inputs.gitref-sha == '' }}
-        config: |-
-          true: 
-            value: ${{ inputs.ref }}
-          false:
-            value: ${{ inputs.gitref-sha }}      
 
     - name: Helm raw render
       if: ${{ inputs.toolchain == 'helm' && inputs.operation == 'deploy' }}


### PR DESCRIPTION
## What:
* Move Deplicated Ref up to have sha usable in helm/helmfile rendering
* Set values `github.repository` and `github.ref` on helmfile renders, allowing them to be used in helm charts and helmfiles

## Why
* datadog enhancement to point at the specific git sha
* generally good to have available on the chart if needed.

## References
* https://github.com/CareCloud/rules_api/pull/42 where I am testing this